### PR TITLE
Add AES-128-CBC support

### DIFF
--- a/pkcs7.go
+++ b/pkcs7.go
@@ -329,7 +329,7 @@ func (p7 *PKCS7) GetOnlySigner() *x509.Certificate {
 }
 
 // ErrUnsupportedAlgorithm tells you when our quick dev assumptions have failed
-var ErrUnsupportedAlgorithm = errors.New("pkcs7: cannot decrypt data: only RSA, DES, DES-EDE3, AES-256-CBC and AES-128-GCM supported")
+var ErrUnsupportedAlgorithm = errors.New("pkcs7: cannot decrypt data: only RSA, DES, DES-EDE3, AES-256-CBC, AES-128-CBC and AES-128-GCM supported")
 
 // ErrNotEncryptedContent is returned when attempting to Decrypt data that is not encrypted data
 var ErrNotEncryptedContent = errors.New("pkcs7: content data is a decryptable data type")
@@ -363,9 +363,15 @@ func (p7 *PKCS7) EncryptionAlgorithm() (int, error) {
 	}
 	alg := data.EncryptedContentInfo.ContentEncryptionAlgorithm.Algorithm
 	switch {
-	case alg.Equal(oidEncryptionAlgorithmDESCBC), alg.Equal(oidEncryptionAlgorithmDESEDE3CBC):
+	case alg.Equal(oidEncryptionAlgorithmDESCBC):
 		return EncryptionAlgorithmDESCBC, nil
-	case alg.Equal(oidEncryptionAlgorithmAES256CBC), alg.Equal(oidEncryptionAlgorithmAES128GCM), alg.Equal(oidEncryptionAlgorithmAES128CBC):
+	case alg.Equal(oidEncryptionAlgorithmDESEDE3CBC):
+		return EncryptionAlgorithmDESEDE3CBC, nil
+	case alg.Equal(oidEncryptionAlgorithmAES256CBC):
+		return EncryptionAlgorithmAES256CBC, nil
+	case alg.Equal(oidEncryptionAlgorithmAES128CBC):
+		return EncryptionAlgorithmAES128CBC, nil
+	case alg.Equal(oidEncryptionAlgorithmAES128GCM):
 		return EncryptionAlgorithmAES128GCM, nil
 	default:
 		return 0, ErrUnsupportedAlgorithm
@@ -418,9 +424,9 @@ func (eci encryptedContentInfo) decrypt(key []byte) ([]byte, error) {
 		block, err = des.NewCipher(key)
 	case alg.Equal(oidEncryptionAlgorithmDESEDE3CBC):
 		block, err = des.NewTripleDESCipher(key)
-	case alg.Equal(oidEncryptionAlgorithmAES256CBC):
-		fallthrough
-	case alg.Equal(oidEncryptionAlgorithmAES128GCM), alg.Equal(oidEncryptionAlgorithmAES128CBC):
+	case alg.Equal(oidEncryptionAlgorithmAES128GCM),
+		alg.Equal(oidEncryptionAlgorithmAES128CBC),
+		alg.Equal(oidEncryptionAlgorithmAES256CBC):
 		block, err = aes.NewCipher(key)
 	}
 
@@ -802,7 +808,10 @@ func DegenerateCertificate(cert []byte) ([]byte, error) {
 
 const (
 	EncryptionAlgorithmDESCBC = iota
+	EncryptionAlgorithmDESEDE3CBC
 	EncryptionAlgorithmAES128GCM
+	EncryptionAlgorithmAES128CBC
+	EncryptionAlgorithmAES256CBC
 )
 
 // ContentEncryptionAlgorithm determines the algorithm used to encrypt the
@@ -812,7 +821,7 @@ var ContentEncryptionAlgorithm = EncryptionAlgorithmDESCBC
 
 // ErrUnsupportedEncryptionAlgorithm is returned when attempting to encrypt
 // content with an unsupported algorithm.
-var ErrUnsupportedEncryptionAlgorithm = errors.New("pkcs7: cannot encrypt content: only DES-CBC and AES-128-GCM supported")
+var ErrUnsupportedEncryptionAlgorithm = errors.New("pkcs7: cannot encrypt content: only DES, DES-EDE3, AES-256-CBC, AES-128-CBC and AES-128-GCM supported")
 
 const nonceSize = 12
 
@@ -875,10 +884,38 @@ func encryptAES128GCM(content []byte) ([]byte, *encryptedContentInfo, error) {
 	return key, &eci, nil
 }
 
-func encryptDESCBC(content []byte) ([]byte, *encryptedContentInfo, error) {
-	// Create DES key & CBC IV
-	key := make([]byte, 8)
-	iv := make([]byte, des.BlockSize)
+func encrypt(content []byte, contentEncryptionAlgorithm int) ([]byte, *encryptedContentInfo, error) {
+	var keySize int
+	var blockSize int
+	var block cipher.Block
+	var alg asn1.ObjectIdentifier
+
+	switch contentEncryptionAlgorithm {
+	case EncryptionAlgorithmDESCBC:
+		keySize = 8
+		blockSize = des.BlockSize
+		alg = oidEncryptionAlgorithmDESCBC
+	case EncryptionAlgorithmDESEDE3CBC:
+		keySize = 24
+		blockSize = des.BlockSize
+		alg = oidEncryptionAlgorithmDESEDE3CBC
+	case EncryptionAlgorithmAES256CBC:
+		keySize = 32
+		blockSize = aes.BlockSize
+		alg = oidEncryptionAlgorithmAES256CBC
+	case EncryptionAlgorithmAES128CBC:
+		keySize = 16
+		blockSize = aes.BlockSize
+		alg = oidEncryptionAlgorithmAES128CBC
+	case EncryptionAlgorithmAES128GCM:
+		return encryptAES128GCM(content)
+	default:
+		return nil, nil, ErrUnsupportedEncryptionAlgorithm
+	}
+
+	// Create key & CBC IV
+	key := make([]byte, keySize)
+	iv := make([]byte, blockSize)
 	_, err := rand.Read(key)
 	if err != nil {
 		return nil, nil, err
@@ -888,11 +925,19 @@ func encryptDESCBC(content []byte) ([]byte, *encryptedContentInfo, error) {
 		return nil, nil, err
 	}
 
-	// Encrypt padded content
-	block, err := des.NewCipher(key)
+	switch contentEncryptionAlgorithm {
+	case EncryptionAlgorithmDESCBC:
+		block, err = des.NewCipher(key)
+	case EncryptionAlgorithmDESEDE3CBC:
+		block, err = des.NewTripleDESCipher(key)
+	case EncryptionAlgorithmAES256CBC, EncryptionAlgorithmAES128CBC:
+		block, err = aes.NewCipher(key)
+	}
+
 	if err != nil {
 		return nil, nil, err
 	}
+
 	mode := cipher.NewCBCEncrypter(block, iv)
 	plaintext, err := pad(content, mode.BlockSize())
 	cyphertext := make([]byte, len(plaintext))
@@ -902,7 +947,7 @@ func encryptDESCBC(content []byte) ([]byte, *encryptedContentInfo, error) {
 	eci := encryptedContentInfo{
 		ContentType: oidData,
 		ContentEncryptionAlgorithm: pkix.AlgorithmIdentifier{
-			Algorithm:  oidEncryptionAlgorithmDESCBC,
+			Algorithm:  alg,
 			Parameters: asn1.RawValue{Tag: 4, Bytes: iv},
 		},
 		EncryptedContent: marshalEncryptedContent(cyphertext),
@@ -956,22 +1001,9 @@ func Encrypt(content []byte, recipients []*x509.Certificate, opts ...Option) ([]
 	for _, opt := range opts {
 		opt(c)
 	}
-	var eci *encryptedContentInfo
-	var key []byte
-	var err error
 
 	// Apply chosen symmetric encryption method
-	switch c.ContentEncryptionAlgorithm {
-	case EncryptionAlgorithmDESCBC:
-		key, eci, err = encryptDESCBC(content)
-
-	case EncryptionAlgorithmAES128GCM:
-		key, eci, err = encryptAES128GCM(content)
-
-	default:
-		return nil, ErrUnsupportedEncryptionAlgorithm
-	}
-
+	key, eci, err := encrypt(content, c.ContentEncryptionAlgorithm)
 	if err != nil {
 		return nil, err
 	}

--- a/pkcs7.go
+++ b/pkcs7.go
@@ -885,10 +885,12 @@ func encryptAES128GCM(content []byte) ([]byte, *encryptedContentInfo, error) {
 }
 
 func encrypt(content []byte, contentEncryptionAlgorithm int) ([]byte, *encryptedContentInfo, error) {
-	var keySize int
-	var blockSize int
-	var block cipher.Block
-	var alg asn1.ObjectIdentifier
+	var (
+		keySize   int
+		blockSize int
+		block     cipher.Block
+		alg       asn1.ObjectIdentifier
+	)
 
 	switch contentEncryptionAlgorithm {
 	case EncryptionAlgorithmDESCBC:

--- a/pkcs7_test.go
+++ b/pkcs7_test.go
@@ -250,7 +250,10 @@ func TestOpenSSLVerifyDetachedSignature(t *testing.T) {
 func TestEncrypt(t *testing.T) {
 	modes := []int{
 		EncryptionAlgorithmDESCBC,
+		EncryptionAlgorithmDESEDE3CBC,
 		EncryptionAlgorithmAES128GCM,
+		EncryptionAlgorithmAES128CBC,
+		EncryptionAlgorithmAES256CBC,
 	}
 
 	for _, mode := range modes {


### PR DESCRIPTION
There were actually 5 different encryption algorithms somewhat supported in different places in code:

DES, DES-EDE3, AES-256-CBC, AES-128-CBC and AES-128-GCM

The decryption code worked and could group some of these together because the decryption code is pretty much the same. When encrypting however the code was still grouping these together which meant it was sometimes doing AES-128-GCM encryption even when asked to do AES-128-CBC encryption.

I updated the unit tests for encryption to test all 5 of these algorithms. Additionally I tested this out through the micromdm project to verify this works in conjunction with the scep protocol. Tested on iOS 9.3.3, 10.1.1, 11.4.1 and macOS 10.9.x - 10.13.x

There is one failing unit test on this branch but as well as in the master branch of the fullsailor project. The verification code looks at the DigestAlgorithm to determine what SignatureAlgorithm to use in verification. Most of the time it picks correctly but sometimes it doesn't (like in the case of the EC2 Identity Document which has a dsaWithSha1 signature. I think this issue would best be addressed separately.